### PR TITLE
[#46] [Chore] Configure git workflow

### DIFF
--- a/.github/workflows/deploy_AppStore.yml
+++ b/.github/workflows/deploy_AppStore.yml
@@ -7,7 +7,7 @@ name: Deploy Build To App Store
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master ]
 
 jobs:
   lint:

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -7,7 +7,7 @@ name: Deploy Release Build To Firebase
 
 on:
   push:
-    branches: [ release/** ]
+    branches: [ main, release/** ]
 
 jobs:
   Lint:


### PR DESCRIPTION
#46 

## What happened
- Configure git workflow for release firebase workflow.
 
## Insight
- Configure release firebase triggers when there's a release PR to main branch instead of  release to Appstore.
