### PR TITLE
[#11] [Integrate] Implement integrate home surveys

### DIFF
--- a/Survey.xcodeproj/project.pbxproj
+++ b/Survey.xcodeproj/project.pbxproj
@@ -34,6 +34,15 @@
 		1CA8B27928B52E7400E5C225 /* CloseButtonModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B27828B52E7400E5C225 /* CloseButtonModifier.swift */; };
 		1CA8B27C28B52FBA00E5C225 /* SurveyQuestionBodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B27B28B52FBA00E5C225 /* SurveyQuestionBodyView.swift */; };
 		1CA8B28028B5310C00E5C225 /* SmallTagTextModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B27F28B5310C00E5C225 /* SmallTagTextModifier.swift */; };
+		1CA8B28628B662AE00E5C225 /* HomeViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B28428B662AB00E5C225 /* HomeViewModelSpec.swift */; };
+		1CA8B28728B662B200E5C225 /* HomeViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B28228B6629600E5C225 /* HomeViewSpec.swift */; };
+		1CA8B28F28B6644800E5C225 /* SurveyRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B28E28B6644800E5C225 /* SurveyRepositoryMock.swift */; };
+		1CA8B29028B6644B00E5C225 /* HomeUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B28C28B6636F00E5C225 /* HomeUseCaseMock.swift */; };
+		1CA8B29128B6724E00E5C225 /* HomeUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B28928B6635D00E5C225 /* HomeUseCaseSpec.swift */; };
+		1CA8B29328B763BC00E5C225 /* Constants+UserDefaultKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B29228B763BC00E5C225 /* Constants+UserDefaultKeys.swift */; };
+		1CA8B29828BBCBBC00E5C225 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B29728BBCBBC00E5C225 /* Storage.swift */; };
+		1CA8B29A28BBCC8800E5C225 /* UserStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B29928BBCC8800E5C225 /* UserStorage.swift */; };
+		1CA8B29D28BCD04F00E5C225 /* Array+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B29C28BCD04E00E5C225 /* Array+Comparable.swift */; };
 		1CAFBB1B28B2AA3800D068DD /* View+Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAFBB1A28B2AA3800D068DD /* View+Transaction.swift */; };
 		1CAFBB2328B2AD4200D068DD /* SurveyDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAFBB2228B2AD4200D068DD /* SurveyDetailViewModel.swift */; };
 		1CAFBB2428B325AE00D068DD /* SurveyDetailViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAFBB1E28B2AC8800D068DD /* SurveyDetailViewSpec.swift */; };
@@ -200,6 +209,15 @@
 		1CA8B27828B52E7400E5C225 /* CloseButtonModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButtonModifier.swift; sourceTree = "<group>"; };
 		1CA8B27B28B52FBA00E5C225 /* SurveyQuestionBodyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyQuestionBodyView.swift; sourceTree = "<group>"; };
 		1CA8B27F28B5310C00E5C225 /* SmallTagTextModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallTagTextModifier.swift; sourceTree = "<group>"; };
+		1CA8B28228B6629600E5C225 /* HomeViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewSpec.swift; sourceTree = "<group>"; };
+		1CA8B28428B662AB00E5C225 /* HomeViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelSpec.swift; sourceTree = "<group>"; };
+		1CA8B28928B6635D00E5C225 /* HomeUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCaseSpec.swift; sourceTree = "<group>"; };
+		1CA8B28C28B6636F00E5C225 /* HomeUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCaseMock.swift; sourceTree = "<group>"; };
+		1CA8B28E28B6644800E5C225 /* SurveyRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyRepositoryMock.swift; sourceTree = "<group>"; };
+		1CA8B29228B763BC00E5C225 /* Constants+UserDefaultKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants+UserDefaultKeys.swift"; sourceTree = "<group>"; };
+		1CA8B29728BBCBBC00E5C225 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
+		1CA8B29928BBCC8800E5C225 /* UserStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStorage.swift; sourceTree = "<group>"; };
+		1CA8B29C28BCD04E00E5C225 /* Array+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Comparable.swift"; sourceTree = "<group>"; };
 		1CAFBB1A28B2AA3800D068DD /* View+Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Transaction.swift"; sourceTree = "<group>"; };
 		1CAFBB1E28B2AC8800D068DD /* SurveyDetailViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyDetailViewSpec.swift; sourceTree = "<group>"; };
 		1CAFBB2028B2ACA000D068DD /* SurveyDetailViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyDetailViewModelSpec.swift; sourceTree = "<group>"; };
@@ -392,10 +410,12 @@
 		0F4C0078B1B4D7C1871DDE54 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				1CA8B29228B763BC00E5C225 /* Constants+UserDefaultKeys.swift */,
 				1CD6FA742897AE6900B4B0D7 /* Constants+API.swift */,
 				1C94DA1B289BA09100ED0984 /* Data+ErrorFormat.swift */,
 				1CD4E336289BC7AA00EA1E8B /* String+Validation.swift */,
 				1CEE603328A6375900748C63 /* Date+StringFormat.swift */,
+				1CA8B29C28BCD04E00E5C225 /* Array+Comparable.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -477,6 +497,40 @@
 				1CA8B27B28B52FBA00E5C225 /* SurveyQuestionBodyView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		1CA8B28128B6627C00E5C225 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				1CA8B28228B6629600E5C225 /* HomeViewSpec.swift */,
+				1CA8B28428B662AB00E5C225 /* HomeViewModelSpec.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		1CA8B28828B662D900E5C225 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				1CA8B28928B6635D00E5C225 /* HomeUseCaseSpec.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		1CA8B28B28B6636600E5C225 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				1CA8B28C28B6636F00E5C225 /* HomeUseCaseMock.swift */,
+				1CA8B28E28B6644800E5C225 /* SurveyRepositoryMock.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		1CA8B29628BBCB9A00E5C225 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				1CA8B29728BBCBBC00E5C225 /* Storage.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 		1CAFBB1C28B2AA5C00D068DD /* View */ = {
@@ -570,6 +624,7 @@
 		1CD4E345289F9B9100EA1E8B /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				1CA8B28128B6627C00E5C225 /* Home */,
 				1CAFBB1D28B2AC5700D068DD /* SurveyDetail */,
 				1CEE604628ABBFF900748C63 /* Splash */,
 				1CD4E346289F9B9E00EA1E8B /* Login */,
@@ -597,6 +652,7 @@
 		1CD4E349289F9BEB00EA1E8B /* Use Case */ = {
 			isa = PBXGroup;
 			children = (
+				1CA8B28828B662D900E5C225 /* Home */,
 				1CEE605028ABCD7B00748C63 /* UserSession */,
 				1C516B7928A15B9400DB7B7B /* Login */,
 			);
@@ -834,6 +890,7 @@
 		3BCCE08012756E065644651B /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				1CA8B28B28B6636600E5C225 /* Home */,
 				1CEE605328ABCDCC00748C63 /* UserSession */,
 				1C516B8828A2C31100DB7B7B /* Keychain */,
 				1C516B8128A1612F00DB7B7B /* Login */,
@@ -903,6 +960,7 @@
 			children = (
 				71A1F95D20E1E58589F4CD31 /* Constants.swift */,
 				1CD4E36628A021A800EA1E8B /* TestConstants.swift */,
+				1CA8B29928BBCC8800E5C225 /* UserStorage.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -940,6 +998,7 @@
 		94932F26FE22743484AC35D9 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				1CA8B29628BBCB9A00E5C225 /* Utilities */,
 				3A7558BC33CF47B1CB689345 /* Application */,
 				7ACFCA11EB70111A5038DA24 /* Constants */,
 				BE4BEBF6D26CB88FDA3C9D1C /* Data */,
@@ -1599,6 +1658,7 @@
 				1C94DA14289983EA00ED0984 /* LoadingView.swift in Sources */,
 				1CB18671288E52E500372D50 /* Driver.swift in Sources */,
 				1CE7C6BC288A786400B0EB1B /* MetaData.swift in Sources */,
+				1CA8B29828BBCBBC00E5C225 /* Storage.swift in Sources */,
 				1C94DA1C289BA09100ED0984 /* Data+ErrorFormat.swift in Sources */,
 				1C516B9A28A3AF0C00DB7B7B /* SurveyItemView.swift in Sources */,
 				1C94DA1C289BA09100ED0984 /* Data+ErrorFormat.swift in Sources */,
@@ -1623,12 +1683,14 @@
 				1CA8B27928B52E7400E5C225 /* CloseButtonModifier.swift in Sources */,
 				2CE4A0682D8CB5A1F2B4C717 /* Navigator+Transition.swift in Sources */,
 				1CB186902891310D00372D50 /* SButtonView.swift in Sources */,
+				1CA8B29328B763BC00E5C225 /* Constants+UserDefaultKeys.swift in Sources */,
 				891B2792ADE1280796829C60 /* Navigator.swift in Sources */,
 				1CD6FA7D2897AF5800B4B0D7 /* Configuration.swift in Sources */,
 				1CD4E35A289FFFED00EA1E8B /* HomeViewModel.swift in Sources */,
 				1CB1869F28923ED200372D50 /* PaddingTextFieldStyle.swift in Sources */,
 				1CD6FA752897AE6900B4B0D7 /* Constants+API.swift in Sources */,
 				1CD6FA6D289797B000B4B0D7 /* Token.swift in Sources */,
+				1CA8B29A28BBCC8800E5C225 /* UserStorage.swift in Sources */,
 				1CE7C6C1288A7F9900B0EB1B /* NoReply.swift in Sources */,
 				1CB186A62893B2D800372D50 /* ImageResource+.swift in Sources */,
 				1CEE603428A6375900748C63 /* Date+StringFormat.swift in Sources */,
@@ -1646,6 +1708,7 @@
 				1CD4E37828A0CF6200EA1E8B /* StoreTokenUseCase.swift in Sources */,
 				1C044B9D28ACD9A5001FF098 /* HomeUseCase.swift in Sources */,
 				1C94DA1E289BBC9B00ED0984 /* ErrorTextModifier.swift in Sources */,
+				1CA8B29D28BCD04F00E5C225 /* Array+Comparable.swift in Sources */,
 				1CEE602828A4ABE100748C63 /* BodyTextModifier.swift in Sources */,
 				1C94DA1A289BA04800ED0984 /* ErrorResponse.swift in Sources */,
 				1CEE603028A4B77D00748C63 /* HeaderHomeView.swift in Sources */,
@@ -1671,10 +1734,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C516B7628A148AF00DB7B7B /* LoginRepositoryMock.swift in Sources */,
+				1CA8B28F28B6644800E5C225 /* SurveyRepositoryMock.swift in Sources */,
 				1C516B8A28A2C31A00DB7B7B /* KeychainServiceMock.swift in Sources */,
+				1CA8B28728B662B200E5C225 /* HomeViewSpec.swift in Sources */,
 				1CAFBB2528B3269A00D068DD /* SurveyDetailViewModelSpec.swift in Sources */,
+				1CA8B29128B6724E00E5C225 /* HomeUseCaseSpec.swift in Sources */,
+				1CA8B28628B662AE00E5C225 /* HomeViewModelSpec.swift in Sources */,
 				1CEE604E28ABCD1D00748C63 /* SplashViewModelSpec.swift in Sources */,
 				1CD4E341289F9B1300EA1E8B /* TestError.swift in Sources */,
+				1CA8B29028B6644B00E5C225 /* HomeUseCaseMock.swift in Sources */,
 				1CEE604F28ABCD2200748C63 /* SplashViewSpec.swift in Sources */,
 				1C516B8528A1619D00DB7B7B /* LoginViewSpec.swift in Sources */,
 				1C516B8728A1CB6700DB7B7B /* StoreTokenUseCaseSpec.swift in Sources */,

--- a/Survey/Sources/Application/SurveyApp.swift
+++ b/Survey/Sources/Application/SurveyApp.swift
@@ -19,7 +19,12 @@ struct SurveyApp: App {
         case .splash:
             SplashView(
                 viewModel: SplashViewModel(
-                    useCase: UserSessionUseCase()
+                    userSessionUseCase: UserSessionUseCase(),
+                    homeUseCase: HomeUseCase(
+                        surveyRepository: SurveyRepository(
+                            api: AuthenticationNetworkAPI()
+                        )
+                    )
                 )
             )
         case .login:
@@ -35,7 +40,16 @@ struct SurveyApp: App {
             )
             LoginView(viewModel: viewModel)
         case .home:
-            HomeView(viewModel: HomeViewModel())
+            let useCase = HomeUseCase(
+                surveyRepository: SurveyRepository(
+                    api: AuthenticationNetworkAPI()
+                )
+            )
+            HomeView(
+                viewModel: HomeViewModel(
+                    useCase: useCase
+                )
+            )
         }
     }
 

--- a/Survey/Sources/Constants/Constants.swift
+++ b/Survey/Sources/Constants/Constants.swift
@@ -6,4 +6,5 @@ enum Constants {
 
     enum API {}
     enum Keys {}
+    enum UserDefaultKeys {}
 }

--- a/Survey/Sources/Constants/UserStorage.swift
+++ b/Survey/Sources/Constants/UserStorage.swift
@@ -1,0 +1,16 @@
+//
+//  UserStorage.swift
+//  Survey
+//
+//  Created by Khanh on 28/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+enum UserStorage {
+
+    @Storage(key: Constants.UserDefaultKeys.cachedSurveyList, defaultValue: [])
+
+    static var cachedSurveyList: [APISurvey]
+}

--- a/Survey/Sources/Data/NetworkAPI/Models/APISurvey.swift
+++ b/Survey/Sources/Data/NetworkAPI/Models/APISurvey.swift
@@ -9,13 +9,17 @@
 import Foundation
 import Japx
 
-struct APISurvey: Survey, JapxCodable {
+struct APISurvey: Survey, JapxCodable, Comparable {
 
     let id: String
     let type: String
     let title: String
     let description: String
     var coverImageURL: String
+
+    static func < (lhs: APISurvey, rhs: APISurvey) -> Bool {
+        return lhs.id < rhs.id
+    }
 }
 
 extension APISurvey {

--- a/Survey/Sources/Domain/Entities/Survey.swift
+++ b/Survey/Sources/Domain/Entities/Survey.swift
@@ -14,3 +14,10 @@ protocol Survey {
     var description: String { get }
     var coverImageURL: String { get }
 }
+
+extension Survey {
+
+    var largeImageURL: URL? {
+        URL(string: coverImageURL + "l")
+    }
+}

--- a/Survey/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/Survey/Sources/Presentation/Modules/Home/HomeView.swift
@@ -100,9 +100,6 @@ struct HomeView: View {
                 isModalPresented = true
             }
         }
-        .onAppear {
-            isModalPresented = false
-        }
         .fullScreenCover(isPresented: $isModalPresented) {
             SurveyDetailView(
                 viewModel: SurveyDetailViewModel(),

--- a/Survey/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/Survey/Sources/Presentation/Modules/Home/HomeView.swift
@@ -27,7 +27,7 @@ struct HomeView: View {
             text: .constant(""),
             content: {
                 ZStack {
-                    tabViewSetup()
+                    setUpTabView()
                         .overlay(alignment: .top) {
                             HeaderHomeView()
                                 .padding(.top, 60.0)
@@ -52,13 +52,13 @@ struct HomeView: View {
         self.input = input
     }
 
-    private func tabViewSetup() -> some View {
+    private func setUpTabView() -> some View {
         let surveyList = Array(output.surveys.enumerated())
 
         return TabView(selection: $tabSelection) {
             ForEach(surveyList, id: \.element.id) { args in
                 let (index, survey) = args
-                surveyItemViewSetup(
+                setUpSurveyItemView(
                     with: index,
                     and: survey
                 )
@@ -69,7 +69,7 @@ struct HomeView: View {
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .overlay(alignment: .leading) {
-            pageControlViewSetup()
+            setUpPageControlView()
         }
         .alert(isPresented: .constant($output.alert.wrappedValue != nil)) {
             Alert(
@@ -83,7 +83,7 @@ struct HomeView: View {
         .edgesIgnoringSafeArea(.all)
     }
 
-    private func surveyItemViewSetup(with index: Int, and survey: Survey) -> some View {
+    private func setUpSurveyItemView(with index: Int, and survey: Survey) -> some View {
         SurveyItemView(
             survey: survey,
             willGoToDetail: {
@@ -109,7 +109,7 @@ struct HomeView: View {
         }
     }
 
-    private func pageControlViewSetup() -> some View {
+    private func setUpPageControlView() -> some View {
         VStack(alignment: .leading) {
             Spacer()
             PageControlView(

--- a/Survey/Sources/Presentation/Modules/Home/HomeViewModel.swift
+++ b/Survey/Sources/Presentation/Modules/Home/HomeViewModel.swift
@@ -9,12 +9,56 @@
 import Combine
 import SwiftUI
 
-struct HomeViewModel {}
+struct HomeViewModel {
+
+    let useCase: HomeUseCaseProtocol
+}
 
 extension HomeViewModel: ViewModel {
 
     func transform(_ input: Input) -> Output {
-        return Output()
+        let errorTracker = ErrorTracker()
+        let activityTracker = ActivityTracker(false)
+        var pageNumber = 0
+        let output = Output()
+
+        input.loadTrigger
+            .map { _ in
+                self.useCase.getSurveyList(pageNumber: pageNumber + 1, pageSize: 10)
+                    .trackError(errorTracker)
+                    .trackActivity(activityTracker)
+                    .asDriver()
+            }
+            .switchToLatest()
+            .map {
+                pageNumber += 1
+                if !UserStorage.cachedSurveyList.hasSameChildren(as: $0 as? [APISurvey] ?? []) {
+                    UserStorage.cachedSurveyList = output.surveys + $0 as? [APISurvey] ?? []
+                    return output.surveys + $0
+                }
+
+                return UserStorage.cachedSurveyList
+            }
+            .assign(to: \.surveys, on: output)
+            .store(in: &output.cancelBag)
+
+        input.willGoToDetail
+            .map { true }
+            .assign(to: \.willGoToDetail, on: output)
+            .store(in: &output.cancelBag)
+
+        errorTracker
+            .receive(on: RunLoop.main)
+            .filter { ($0 as? SError) != .empty }
+            .map { AlertMessage(error: $0) }
+            .assign(to: \.alert, on: output)
+            .store(in: &output.cancelBag)
+
+        activityTracker
+            .receive(on: RunLoop.main)
+            .assign(to: \.isLoading, on: output)
+            .store(in: &output.cancelBag)
+        return output
     }
 }
 
@@ -22,10 +66,27 @@ extension HomeViewModel: ViewModel {
 
 extension HomeViewModel {
 
-    final class Input: ObservableObject {}
+    final class Input: ObservableObject {
+
+        let loadTrigger: Driver<Void>
+        let willGoToDetail: Driver<Void>
+
+        init(
+            loadTrigger: Driver<Void>,
+            willGoToDetail: Driver<Void>
+        ) {
+            self.loadTrigger = loadTrigger
+            self.willGoToDetail = willGoToDetail
+        }
+    }
 
     final class Output: ObservableObject {
 
         var cancelBag = CancelBag()
+
+        @Published var alert: AlertMessage?
+        @Published var isLoading = false
+        @Published var surveys = [Survey]()
+        @Published var willGoToDetail = false
     }
 }

--- a/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
+++ b/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct SurveyItemView: View {
 
-    @State var isShowing = false
     @State private var fadeInOut = false
 
     let survey: Survey
@@ -19,11 +18,14 @@ struct SurveyItemView: View {
     var body: some View {
         ZStack {
             mainImageSetup()
-            componentsSetup()
-                .frame(
-                    width: UIScreen.main.bounds.width,
-                    height: UIScreen.main.bounds.height
-                )
+                .overlay {
+                    componentsSetup()
+                        .frame(
+                            width: UIScreen.main.bounds.width,
+                            height: UIScreen.main.bounds.height
+                        )
+                        .opacity(fadeInOut ? 1.0 : 0.0)
+                }
         }
         .onAppear(perform: {
             fadeInOut = false
@@ -31,7 +33,6 @@ struct SurveyItemView: View {
                 fadeInOut.toggle()
             }
         })
-        .opacity(fadeInOut ? 1.0 : 0.0)
     }
 
     private func componentsSetup() -> some View {
@@ -68,11 +69,33 @@ struct SurveyItemView: View {
     }
 
     private func mainImageSetup() -> some View {
-        // TODO: Remove dummy cover image url
-        Image(survey.coverImageURL)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .opacity(0.6)
-            .edgesIgnoringSafeArea(.all)
+        AsyncImage(url: survey.largeImageURL, transaction: Transaction(animation: .easeInOut(duration: 1.0))) { phase in
+            switch phase {
+            case .empty:
+                ProgressView()
+                    .hidden()
+            case let .success(image):
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .edgesIgnoringSafeArea(.all)
+                    .transition(.opacity)
+                    .onAppear(perform: {
+                        fadeInOut = true
+                    })
+            case .failure:
+                Assets.ic_background.image
+                    .resizable()
+                    .scaledToFill()
+                    .edgesIgnoringSafeArea(.all)
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .opacity(fadeInOut ? 0.6 : 0.0)
+        .frame(
+            width: UIScreen.main.bounds.width,
+            height: UIScreen.main.bounds.height
+        )
     }
 }

--- a/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
+++ b/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
@@ -69,7 +69,10 @@ struct SurveyItemView: View {
     }
 
     private func mainImageSetup() -> some View {
-        AsyncImage(url: survey.largeImageURL, transaction: Transaction(animation: .easeInOut(duration: 1.0))) { phase in
+        AsyncImage(
+            url: survey.largeImageURL,
+            transaction: Transaction(animation: .easeInOut(duration: 1.0))
+        ) { phase in
             switch phase {
             case .empty:
                 ProgressView()

--- a/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
+++ b/Survey/Sources/Presentation/Modules/Home/Views/SurveyItemView.swift
@@ -17,9 +17,9 @@ struct SurveyItemView: View {
 
     var body: some View {
         ZStack {
-            mainImageSetup()
+            setUpMainImage()
                 .overlay {
-                    componentsSetup()
+                    setUpComponents()
                         .frame(
                             width: UIScreen.main.bounds.width,
                             height: UIScreen.main.bounds.height
@@ -35,7 +35,7 @@ struct SurveyItemView: View {
         })
     }
 
-    private func componentsSetup() -> some View {
+    private func setUpComponents() -> some View {
         VStack(alignment: .leading) {
             Spacer()
             HStack(alignment: .bottom) {
@@ -68,7 +68,7 @@ struct SurveyItemView: View {
         }
     }
 
-    private func mainImageSetup() -> some View {
+    private func setUpMainImage() -> some View {
         AsyncImage(
             url: survey.largeImageURL,
             transaction: Transaction(animation: .easeInOut(duration: 1.0))

--- a/Survey/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/Survey/Sources/Presentation/Modules/Login/LoginView.swift
@@ -33,12 +33,12 @@ struct LoginView: View {
         LoadingView(isShowing: $output.isLoading, text: .constant("")) {
             GeometryReader { geo in
                 ZStack {
-                    backgroundSetup()
+                    setupBackground()
                     VStack(spacing: 0.0) {
-                        logoSetup()
+                        setUpLogo()
                             .frame(height: geo.size.height * (1.0 / 3.0))
                             .offset(y: 20.0)
-                        componentSetup()
+                        setUpComponent()
                             .frame(height: geo.size.height * (1.0 / 3.0))
                         Spacer()
                             .frame(height: geo.size.height * (1.0 / 3.0))
@@ -68,7 +68,7 @@ struct LoginView: View {
         self.input = input
     }
 
-    private func backgroundSetup() -> some View {
+    private func setupBackground() -> some View {
         Assets.ic_background.image
             .resizable()
             .aspectRatio(contentMode: .fill)
@@ -84,10 +84,10 @@ struct LoginView: View {
             .edgesIgnoringSafeArea(.all)
     }
 
-    private func componentSetup() -> some View {
+    private func setUpComponent() -> some View {
         VStack(alignment: .leading, spacing: 0.0) {
-            emailSetup()
-            passwordSetup()
+            setUpEmail()
+            setUpPassword()
             SButtonView(
                 isValid: $output.isLoginEnabled,
                 action: { logInTrigger.send(()) },
@@ -98,7 +98,7 @@ struct LoginView: View {
         .padding([.leading, .trailing], 24.0)
     }
 
-    private func emailSetup() -> some View {
+    private func setUpEmail() -> some View {
         VStack(alignment: .leading, spacing: 0.0) {
             TextField("", text: $input.email)
                 .modifier(PlaceholderModifier(showPlaceHolder: input.email.isEmpty, placeholder: "Email"))
@@ -112,7 +112,7 @@ struct LoginView: View {
         }
     }
 
-    private func passwordSetup() -> some View {
+    private func setUpPassword() -> some View {
         VStack(alignment: .leading, spacing: 0.0) {
             SecureField("", text: $input.password)
                 .modifier(PlaceholderModifier(showPlaceHolder: input.password.isEmpty, placeholder: "Password"))
@@ -126,7 +126,7 @@ struct LoginView: View {
         }
     }
 
-    private func logoSetup() -> some View {
+    private func setUpLogo() -> some View {
         VStack {
             Assets.ic_logo.image
                 .resizable()

--- a/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
+++ b/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
@@ -12,14 +12,60 @@ import UIKit
 
 struct SplashView: View {
 
-    private var input: SplashViewModel.Input
+    @ObservedObject var input: SplashViewModel.Input
     @ObservedObject var output: SplashViewModel.Output
-
     @EnvironmentObject private var appRouter: AppRouter
-
     @State private var fadeInOut = false
 
+    private let willFetchSurveysTrigger = PassthroughSubject<Void, Never>()
+    private let loadTrigger = PassthroughSubject<Void, Never>()
+
     var body: some View {
+        LoadingView(
+            isShowing: $output.isLoading,
+            text: .constant(""),
+            content: {
+                viewSetup()
+                    .preferredColorScheme(.dark)
+                    .onAppear(perform: {
+                        loadTrigger.send()
+                    })
+                    .onReceive(output.$hasUserLoggedIn.dropFirst()) { hasUserLoggedIn in
+                        guard hasUserLoggedIn else {
+                            appRouter.state = .login
+                            return
+                        }
+                        willFetchSurveysTrigger.send()
+                    }
+                    .onReceive(output.$fetchSuccessfully, perform: {
+                        guard $0 else { return }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            appRouter.state = .home
+                        }
+                    })
+                    .alert(isPresented: .constant($output.alert.wrappedValue != nil)) {
+                        Alert(
+                            title: Text(output.alert?.title ?? ""),
+                            message: Text(output.alert?.message ?? ""),
+                            dismissButton: .default(Text("OK"), action: {
+                                $output.alert.wrappedValue = nil
+                            })
+                        )
+                    }
+            }
+        )
+    }
+
+    init(viewModel: SplashViewModel) {
+        let input = SplashViewModel.Input(
+            loadTrigger: loadTrigger.asDriver(),
+            willFetchSurveysTrigger: willFetchSurveysTrigger.asDriver()
+        )
+        output = viewModel.transform(input)
+        self.input = input
+    }
+
+    private func viewSetup() -> some View {
         ZStack {
             Assets.ic_background.image
                 .resizable()
@@ -36,18 +82,6 @@ struct SplashView: View {
                 })
                 .opacity(fadeInOut ? 1.0 : 0.0)
         }
-        .preferredColorScheme(.dark)
-        .onReceive(output.$hasUserLoggedIn) { hasUserLoggedIn in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                appRouter.state = hasUserLoggedIn ? .home : .login
-            }
-        }
-    }
-
-    init(viewModel: SplashViewModel) {
-        let input = SplashViewModel.Input(loadTrigger: Driver.just(()))
-        output = viewModel.transform(input)
-        self.input = input
     }
 }
 
@@ -55,7 +89,12 @@ struct SplashViewPreView: PreviewProvider {
 
     static var previews: some View {
         let viewModel = SplashViewModel(
-            useCase: UserSessionUseCase()
+            userSessionUseCase: UserSessionUseCase(),
+            homeUseCase: HomeUseCase(
+                surveyRepository: SurveyRepository(
+                    api: AuthenticationNetworkAPI()
+                )
+            )
         )
         return SplashView(viewModel: viewModel)
     }

--- a/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
+++ b/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
@@ -25,7 +25,7 @@ struct SplashView: View {
             isShowing: $output.isLoading,
             text: .constant(""),
             content: {
-                viewSetup()
+                setUpView()
                     .preferredColorScheme(.dark)
                     .onAppear(perform: {
                         loadTrigger.send()
@@ -65,7 +65,7 @@ struct SplashView: View {
         self.input = input
     }
 
-    private func viewSetup() -> some View {
+    private func setUpView() -> some View {
         ZStack {
             Assets.ic_background.image
                 .resizable()

--- a/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -25,8 +25,8 @@ struct SurveyDetailView: View {
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             ZStack(alignment: .topLeading) {
-                mainImageSetup()
-                componentsSetup()
+                setUpMainImage()
+                setUpComponents()
             }
         }
         .overlay(content: {
@@ -88,7 +88,7 @@ struct SurveyDetailView: View {
         self.input = input
     }
 
-    private func componentsSetup() -> some View {
+    private func setUpComponents() -> some View {
         VStack(alignment: .leading) {
             Button {
                 withAnimation(Animation.linear(duration: 0.5)) {
@@ -124,7 +124,7 @@ struct SurveyDetailView: View {
         .opacity(fadeInOut ? 1.0 : 0.0)
     }
 
-    private func mainImageSetup() -> some View {
+    private func setUpMainImage() -> some View {
         AsyncImage(url: survey.largeImageURL) { phase in
             switch phase {
             case .empty:

--- a/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -60,11 +60,6 @@ struct SurveyDetailView: View {
             withAnimation(Animation.easeInOut(duration: 1.0)) {
                 fadeInOut.toggle()
             }
-
-            didScaleEffect = false
-            withAnimation(Animation.linear(duration: 0.5)) {
-                didScaleEffect.toggle()
-            }
         })
         .onReceive(output.$willGoToNextSurvey) {
             guard $0 else { return }
@@ -130,20 +125,36 @@ struct SurveyDetailView: View {
     }
 
     private func mainImageSetup() -> some View {
-        // TODO: Remove dummy cover image url
-        Image(survey.coverImageURL)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .scaleEffect(
-                x: didScaleEffect ? 1.3 : 1.0,
-                y: didScaleEffect ? 1.3 : 1.0,
-                anchor: .trailing
-            )
-            .edgesIgnoringSafeArea(.all)
-            .frame(
-                width: UIScreen.main.bounds.width,
-                height: UIScreen.main.bounds.height
-            )
-            .opacity(0.6)
+        AsyncImage(url: survey.largeImageURL) { phase in
+            switch phase {
+            case .empty:
+                ProgressView()
+            case let .success(image):
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .edgesIgnoringSafeArea(.all)
+                    .opacity(0.6)
+                    .onAppear {
+                        didScaleEffect = false
+                        withAnimation(Animation.linear(duration: 1.0)) {
+                            didScaleEffect.toggle()
+                        }
+                    }
+            case .failure:
+                Image(systemName: "photo")
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .scaleEffect(
+            x: didScaleEffect ? 1.3 : 1.0,
+            y: didScaleEffect ? 1.3 : 1.0,
+            anchor: .top
+        )
+        .frame(
+            width: UIScreen.main.bounds.width,
+            height: UIScreen.main.bounds.height
+        )
     }
 }

--- a/Survey/Sources/Presentation/Modules/SurveyQuestion/SurveyQuestionView.swift
+++ b/Survey/Sources/Presentation/Modules/SurveyQuestion/SurveyQuestionView.swift
@@ -34,8 +34,8 @@ struct SurveyQuestionView: View {
             }
         )
         .overlay {
-            closeButtonSetup()
-            nextQuestionButtonSetup()
+            setUpCloseButton()
+            setUpNextQuestionButton()
         }
         .padding(.bottom, 54.0)
         .padding(.top, 54.0)
@@ -50,7 +50,7 @@ struct SurveyQuestionView: View {
         .preferredColorScheme(.dark)
     }
 
-    private func closeButtonSetup() -> some View {
+    private func setUpCloseButton() -> some View {
         ZStack(alignment: .top) {
             VStack {
                 HStack {
@@ -70,7 +70,7 @@ struct SurveyQuestionView: View {
         }
     }
 
-    private func nextQuestionButtonSetup() -> some View {
+    private func setUpNextQuestionButton() -> some View {
         ZStack(alignment: .bottom) {
             VStack {
                 Spacer()

--- a/Survey/Sources/Supports/Extensions/Foundation/Array+Comparable.swift
+++ b/Survey/Sources/Supports/Extensions/Foundation/Array+Comparable.swift
@@ -1,0 +1,16 @@
+//
+//  Array+Comparable.swift
+//  Survey
+//
+//  Created by Khanh on 29/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+extension Array where Element: Comparable {
+
+    func hasSameChildren(as other: [Element]) -> Bool {
+        return count == other.count && sorted() == other.sorted()
+    }
+}

--- a/Survey/Sources/Supports/Extensions/Foundation/Constants+UserDefaultKeys.swift
+++ b/Survey/Sources/Supports/Extensions/Foundation/Constants+UserDefaultKeys.swift
@@ -1,0 +1,15 @@
+//  swiftlint:disable:this file_name
+//
+//  Constants+UserDefaultKeys.swift
+//  Survey
+//
+//  Created by Khanh on 25/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+extension Constants.UserDefaultKeys {
+
+    static let cachedSurveyList = "cachedSurveyList"
+}

--- a/Survey/Sources/Utilities/Storage.swift
+++ b/Survey/Sources/Utilities/Storage.swift
@@ -1,0 +1,43 @@
+//
+//  Storage.swift
+//  Survey
+//
+//  Created by Khanh on 28/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper
+struct Storage<T: Codable> {
+
+    let userDefaults: UserDefaults
+    let key: String
+    let defaultValue: T
+
+    var wrappedValue: T {
+        get {
+            if let data = userDefaults.data(forKey: key) {
+                if let value = try? JSONDecoder().decode(T.self, from: data) {
+                    return value
+                }
+            }
+            return defaultValue
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                userDefaults.set(data, forKey: key)
+            }
+        }
+    }
+
+    init(
+        userDefaults: UserDefaults = UserDefaults.standard,
+        key: String,
+        defaultValue: T
+    ) {
+        self.userDefaults = userDefaults
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+}

--- a/SurveyTests/Domain/Use Case/Home/HomeUseCaseSpec.swift
+++ b/SurveyTests/Domain/Use Case/Home/HomeUseCaseSpec.swift
@@ -1,0 +1,41 @@
+//
+//  HomeUseCaseSpec.swift
+//  Survey
+//
+//  Created by Khanh on 24/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import Nimble
+import Quick
+@testable import Survey
+
+final class HomeUseCaseSpec: QuickSpec {
+
+    override func spec() {
+        var useCase: HomeUseCase!
+        var repository: SurveyRepositoryMock!
+
+        describe("a HomeUseCase") {
+
+            beforeEach {
+                repository = SurveyRepositoryMock()
+                useCase = HomeUseCase(
+                    surveyRepository: repository
+                )
+            }
+
+            context("when getSurveyListCalled is called") {
+
+                beforeEach {
+                    _ = useCase.getSurveyList(pageNumber: 1, pageSize: 10)
+                }
+
+                it("returns correct response") {
+                    expect(repository.getSurveyListCalled) == true
+                }
+            }
+        }
+    }
+}

--- a/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
+++ b/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
@@ -46,11 +46,11 @@ final class HomeViewModelSpec: QuickSpec {
                     willGoToDetail.send()
                 }
 
-                it("has getSurveyListCalled called") {
+                it("has getSurveyList called") {
                     expect(useCase.getSurveyListCalled) == true
                 }
 
-                it("returns output with not empty items and move to detail") {
+                it("returns output with not empty items") {
                     expect(self.output.surveys).toNotEventually(beEmpty())
                 }
 

--- a/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
+++ b/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
@@ -39,12 +39,20 @@ final class HomeViewModelSpec: QuickSpec {
 
             context("when load survey list returns success") {
 
-                it("returns output with not empty items and move to detail") {
+                beforeEach {
                     loadTrigger.send()
                     willGoToDetail.send()
-
+                }
+                
+                it("has getSurveyListCalled called") {
                     expect(useCase.getSurveyListCalled) == true
+                }
+
+                it("returns output with not empty items and move to detail") {
                     expect(self.output.surveys).toNotEventually(beEmpty())
+                }
+                
+                it("moves to detail") {
                     expect(self.output.willGoToDetail).toEventually(beTrue())
                 }
             }

--- a/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
+++ b/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
@@ -1,0 +1,64 @@
+//
+//  HomeViewModelSpec.swift
+//  Survey
+//
+//  Created by Khanh on 24/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import Nimble
+import Quick
+import SwiftUI
+
+@testable import Survey
+
+final class HomeViewModelSpec: QuickSpec {
+
+    var input: HomeViewModel.Input!
+    var output: HomeViewModel.Output!
+
+    override func spec() {
+        var viewModel: HomeViewModel!
+        var useCase: HomeUseCaseMock!
+        let loadTrigger = PassthroughSubject<Void, Never>()
+        let willGoToDetail = PassthroughSubject<Void, Never>()
+
+        describe("a HomeViewModel") {
+
+            beforeEach {
+                useCase = HomeUseCaseMock()
+                viewModel = HomeViewModel(useCase: useCase)
+
+                self.input = HomeViewModel.Input(
+                    loadTrigger: loadTrigger.eraseToAnyPublisher(),
+                    willGoToDetail: willGoToDetail.eraseToAnyPublisher()
+                )
+                self.output = viewModel.transform(self.input)
+            }
+
+            context("when load survey list returns success") {
+
+                it("returns output with not empty items and move to detail") {
+                    loadTrigger.send()
+                    willGoToDetail.send()
+
+                    expect(useCase.getSurveyListCalled) == true
+                    expect(self.output.surveys).toNotEventually(beEmpty())
+                    expect(self.output.willGoToDetail).toEventually(beTrue())
+                }
+            }
+
+            context("when load survey list returns failure with error alert") {
+
+                it("returns output with alert displayed") {
+                    useCase.getSurveyListReturnValue = .failure(TestError())
+
+                    loadTrigger.send()
+
+                    expect(self.output.alert).toEventuallyNot(beNil())
+                }
+            }
+        }
+    }
+}

--- a/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
+++ b/SurveyTests/Presentation/Modules/Home/HomeViewModelSpec.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Nimble. All rights reserved.
 //
 
+//  swiftlint:disable closure_body_length
+
 import Combine
 import Nimble
 import Quick
@@ -43,7 +45,7 @@ final class HomeViewModelSpec: QuickSpec {
                     loadTrigger.send()
                     willGoToDetail.send()
                 }
-                
+
                 it("has getSurveyListCalled called") {
                     expect(useCase.getSurveyListCalled) == true
                 }
@@ -51,7 +53,7 @@ final class HomeViewModelSpec: QuickSpec {
                 it("returns output with not empty items and move to detail") {
                     expect(self.output.surveys).toNotEventually(beEmpty())
                 }
-                
+
                 it("moves to detail") {
                     expect(self.output.willGoToDetail).toEventually(beTrue())
                 }

--- a/SurveyTests/Presentation/Modules/Home/HomeViewSpec.swift
+++ b/SurveyTests/Presentation/Modules/Home/HomeViewSpec.swift
@@ -1,0 +1,37 @@
+//
+//  HomeViewSpec.swift
+//  Survey
+//
+//  Created by Khanh on 24/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import Nimble
+import Quick
+
+@testable import Survey
+
+final class HomeViewSpec: QuickSpec {
+
+    override func spec() {
+        var homeView: HomeView!
+
+        describe("a homeView") {
+
+            beforeEach {
+                homeView = HomeView(
+                    viewModel: HomeViewModel(
+                        useCase: HomeUseCaseMock())
+                )
+            }
+
+            context("has onAppear called") {
+
+                it("is not loading") {
+                    expect(homeView.output.isLoading) == false
+                }
+            }
+        }
+    }
+}

--- a/SurveyTests/Presentation/Modules/Splash/SplashViewSpec.swift
+++ b/SurveyTests/Presentation/Modules/Splash/SplashViewSpec.swift
@@ -15,23 +15,27 @@ import Quick
 final class SplashViewSpec: QuickSpec {
 
     override func spec() {
-        var useCase: UserSessionUseCaseMock!
+        var userSessionUseCase: UserSessionUseCaseMock!
+        var homeUseCase: HomeUseCaseMock!
+        var splashView: SplashView!
 
         describe("a SplashView") {
 
             beforeEach {
-                useCase = UserSessionUseCaseMock()
-                _ = SplashView(
+                userSessionUseCase = UserSessionUseCaseMock()
+                homeUseCase = HomeUseCaseMock()
+                splashView = SplashView(
                     viewModel: SplashViewModel(
-                        useCase: useCase
+                        userSessionUseCase: userSessionUseCase,
+                        homeUseCase: homeUseCase
                     )
                 )
             }
 
-            context("has checked user session called") {
+            context("has onAppear called") {
 
-                it("return correct response") {
-                    expect(useCase.hasUserLoggedInCalled) == true
+                it("is not loading") {
+                    expect(splashView.output.isLoading) == false
                 }
             }
         }

--- a/SurveyTests/Sources/Mocks/Home/HomeUseCaseMock.swift
+++ b/SurveyTests/Sources/Mocks/Home/HomeUseCaseMock.swift
@@ -1,0 +1,22 @@
+//
+//  HomeUseCaseMock.swift
+//  Survey
+//
+//  Created by Khanh on 24/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+@testable import Survey
+
+final class HomeUseCaseMock: HomeUseCaseProtocol {
+
+    var getSurveyListCalled = false
+
+    var getSurveyListReturnValue = Result<[Survey], Error>.success(APISurvey.dummyList)
+
+    func getSurveyList(pageNumber: Int, pageSize: Int) -> Observable<[Survey]> {
+        getSurveyListCalled = true
+        return getSurveyListReturnValue.publisher.eraseToAnyPublisher()
+    }
+}

--- a/SurveyTests/Sources/Mocks/Home/SurveyRepositoryMock.swift
+++ b/SurveyTests/Sources/Mocks/Home/SurveyRepositoryMock.swift
@@ -1,0 +1,31 @@
+//
+//  SurveyRepositoryMock.swift
+//  SurveyTests
+//
+//  Created by Khanh on 24/08/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+@testable import Survey
+
+final class SurveyRepositoryMock: SurveyRepositoryProtocol {
+
+    var getSurveyDetailCalled = false
+
+    var getSurveyDetailReturnValue = Observable.just(APISurvey.dummyList[0])
+
+    var getSurveyListCalled = false
+
+    var getSurveyListReturnValue = Observable.just(APISurvey.dummyList)
+
+    func getSurveyList(pageNumber: Int, pageSize: Int) -> Observable<[Survey]> {
+        getSurveyListCalled = true
+        return getSurveyListReturnValue.map { $0 as [Survey] }.asObservable()
+    }
+
+    func getSurveyDetail(id: String) -> Observable<Survey> {
+        getSurveyDetailCalled = true
+        return getSurveyDetailReturnValue.map { $0 as Survey }.asObservable()
+    }
+}


### PR DESCRIPTION
#11 

## What happened

- Show list of surveys on Home Screen
 
## Insight

- Fetch the list of surveys when opening the app
- Show list of surveys as a horizontal scrollable
- Cached the list of surveys onto the device; in the meantime, the app also fetch data  from the API as well, if there are any changes, then update the cache and propagated to Home Screen.
- Select the next button to move to detail screen.
- Load more when there's more survey after each 10 ones.
- Update unit test on splash screen.
- Write unit test for home screen.
 
## Proof Of Work


https://user-images.githubusercontent.com/25881847/187179214-88fba594-95a0-4b5e-aa45-74f9e7337187.mp4


